### PR TITLE
Problem with libxmljs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   }
 , "dependencies" :
   { "jsdom" : "0.2.x"
-  , "libxmljs" : "git://github.com/znerol/libxmljs.git#xmlwriter-0.5.4"
+  , "libxmljs" : "0.8.1"
   }
 , "devDependencies" :
   { "browserify" : "1.10.x"


### PR DESCRIPTION
Not sure exactly what's causing the issue but with the libxml 0.5.4 from git and Node 0.8.x you will get the following error:

```
node_modules/libxmljs/node_modules/bindings/bindings.js:79
    Error: Symbol libxmljs_module not found.
```

Updating the dependency to the latest version seems to resolve the issue.
