### PR TITLE
NodeJS 10.x: use libxmljs 0.19.3 for libxmljs/libxmljs#523

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "jsdom": "^6.5.1",
-    "libxmljs": "git://github.com/znerol/libxmljs.git#xmlwriter-0.18.0"
+    "libxmljs": "^0.19.3"
   },
   "devDependencies": {
     "browserify": "^14.0.0",


### PR DESCRIPTION
@znerol, libxmljs 0.19.3 provides support for NodeJS 10.x; see libxmljs/libxmljs#523
I am using this xmlshim NPM library as a dependency pulled in from another NPM library (node-blockly), and `git://github.com/znerol/libxmljs.git#xmlwriter-0.18.0` does not allowing building under NodeJS 10.x, at least in my environment.

Please let me know if you need any steps to reproduce. It should be as straightforward as trying to npm install xmlshim under NodeJS 10.x